### PR TITLE
Add six as dependency to fix import issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ setup(
     author='Alastair Mccormack',
     author_email='alastair at alu.media',
     description='MP4 / ISO base media file format (ISO/IEC 14496-12 - MPEG-4 Part 12) file parser',
-    requires=['bitstring'],
-    install_requires=['bitstring'],
+    requires=['bitstring', 'six'],
+    install_requires=['bitstring', 'six'],
     long_description=long_description,
     data_files=[('', ['README.md'])]
 )


### PR DESCRIPTION
Fix this problem for projects not already using six: 
ImportError: No module named 'six'